### PR TITLE
scss functions replace "/" with calc()

### DIFF
--- a/src/styles/functions.scss
+++ b/src/styles/functions.scss
@@ -41,16 +41,16 @@ $rem-to-px-base: 16px !default;
 
       @if $rem-to-px-conversion {
         @if $unit == "rem" {
-          $list: append($list, $value / 1rem * $rem-to-px-base);
+          $list: append($list, calc($value / 1rem * $rem-to-px-base));
         } @else {
           $list: append($list, $value);
         }
       } @else if $unit == "rem" or $unit == "" {
         $list: append($list, $value);
       } @else if $unit == unit($rem-to-px-base) {
-        $list: append($list, $value / $rem-to-px-base + 0rem);
+        $list: append($list, calc($value / $rem-to-px-base) + 0rem);
       } @else if $unit == "em" {
-        $list: append($list, $value / 1em + 0rem);
+        $list: append($list, calc($value / 1em) + 0rem);
       } @else {
         @warn "There is currently no unit conversion for #{$unit}";
       }


### PR DESCRIPTION
After updating the dependencies the [renovate](https://github.com/marketplace/renovate) bot recommended sass-loader was throwing the following warnings
<img width="1223" alt="Screenshot 2022-05-05 at 09 37 20" src="https://user-images.githubusercontent.com/50147356/166887324-a19e4b27-1f7b-400a-b8ca-dcd61ed1c94a.png">

That should be solved with this PR